### PR TITLE
イベントの起点をFastAPIとSlack Appの両方に併存させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Slack AppとはSlack ワークスペースで実行するアプリケーショ�
 18. 左サイドバーから「Basic Information」を選択し、「Signing Secret」項目の「Show」を押下し表示させたのち、内容をコピーし、メモしておく
 19. .envのSLACK_BOT_TOKENに17、SLACK_SIGNING_SECRETに18のトークンを設定する。
 20. 左サイドバーから「Event Subscriptions」を選択
-21. Enable Events」を「On」にし、「Request URL」にngrokで公開したバックエンドのURLを指定
+21. Enable Events」を「On」にし、「Request URL」にngrokで公開したバックエンドのURL(イベントハンドラを指す)を指定
+    <https://hoge-222-229-40-231.ngrok-free.app/slack/events>
 22. 下部の「Subscribe to bot events」タブ内で以下3つのイベントを追加
     - message.channels
     - message.groups

--- a/apis/main.py
+++ b/apis/main.py
@@ -1,5 +1,7 @@
 import os
 from fastapi import FastAPI, Request, Response
+from slack_bolt import App
+from slack_bolt.adapter.fastapi import SlackRequestHandler
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -16,8 +18,15 @@ scheduler = None
 
 # Slack clientの初期化
 client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
-signature_verifier = SignatureVerifier(os.environ.get("SLACK_SIGNING_SECRET"))
 
+slack_app = App(
+    token=os.environ.get("SLACK_BOT_TOKEN"),
+    signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
+    # process_before_response=True,
+    # request_verification_enabled=False,
+    # ignoring_self_events_enabled=False  # self eventsの無視を無効にする
+)
+handler = SlackRequestHandler(slack_app)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -62,99 +71,25 @@ def scheduled_task():
     # 特定のユーザーにDMを送信
     send_dm_to_user("U07E21NGPA7", "定期的なDMだがや")
 
+@slack_app.event("message")
+def handle_message_events(body, say, logger):
+    logger.debug(f"Received event: {body}")
+    event = body["event"]
+    channel_type = event.get("channel_type")
+    logger.info(f"Message received in channel type: {channel_type}")
+
+    if channel_type == "im":
+        logger.info("Responding to DM")
+        say(event["text"] + " だがや")
+    else:
+        logger.info("Responding to channel message")
+        say(event["text"] + " ですぞえ")
 
 @app.post("/slack/events")
-async def slack_events(request: Request):
-    # リクエストボディを取得
-    body = await request.body()
-    body_text = body.decode("utf-8")
-    logger.debug(f"Received Slack event: {body_text}")
-
-    # イベントデータの解析
-    event_data = await request.json()
-
-    # URL検証チャレンジへの応答
-    if event_data.get("type") == "url_verification":
-        logger.info("Responding to Slack URL verification challenge")
-        return {"challenge": event_data.get("challenge")}
-
-    # Slack-Signature ヘッダーを取得
-    signature = request.headers.get("X-Slack-Signature", "")
-    # リクエストタイムスタンプを取得
-    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
-
-    # リクエストの検証
-    if not signature_verifier.is_valid(body, signature, timestamp):
-        logger.warning("Invalid Slack request signature")
-        return Response(status_code=403, content="Invalid request")
-
-    # その他のイベント処理
-    if event_data.get("type") == "event_callback":
-        event = event_data.get("event", {})
-        event_type = event.get("type")
-
-        if event_type == "message":
-            # メッセージイベントの処理
-            channel = event.get("channel")
-            user = event.get("user")
-            text = event.get("text")
-            logger.info(
-                f"Received message: {text} from user {user} in channel {channel}"
-            )
-
-    return Response(status_code=200)
-
+async def slack_events(req: Request):
+    return await handler.handle(req)
 
 @app.get("/")
 def read_root():
     return {"Hello": "Scheduled Slack Bot World"}
 
-
-# import os
-# from fastapi import FastAPI, Request
-# from slack_bolt import App
-# from slack_bolt.adapter.fastapi import SlackRequestHandler
-# import logging
-
-# logging.basicConfig(level=logging.DEBUG)
-# logger = logging.getLogger(__name__)
-
-
-# slack_app = App(
-#     token=os.environ.get("SLACK_BOT_TOKEN"),
-#     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
-#     # process_before_response=True,
-#     # request_verification_enabled=False,
-#     # ignoring_self_events_enabled=False  # self eventsの無視を無効にする
-# )
-# app = FastAPI()
-# handler = SlackRequestHandler(slack_app)
-
-
-# # @slack_app.event("message")
-# # def handle_message_events(body, say):
-# #     message = body["event"]
-# #     say(message["text"]+" ですぞえ")
-
-# @slack_app.event("message")
-# def handle_message_events(body, say, logger):
-#     logger.debug(f"Received event: {body}")
-#     event = body["event"]
-#     channel_type = event.get("channel_type")
-#     logger.info(f"Message received in channel type: {channel_type}")
-
-#     if channel_type == "im":
-#         logger.info("Responding to DM")
-#         say(event["text"] + " だがや")
-#     else:
-#         logger.info("Responding to channel message")
-#         say(event["text"] + " ですぞえ")
-
-
-# @app.post("/slack/events")
-# async def slack_events(req: Request):
-#     return await handler.handle(req)
-
-# @app.get("/")
-# def read_root():
-#     return {"Hello": "ngrok World"}

--- a/apis/main.py
+++ b/apis/main.py
@@ -1,5 +1,5 @@
 import os
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request
 from slack_bolt import App
 from slack_bolt.adapter.fastapi import SlackRequestHandler
 from slack_sdk import WebClient
@@ -7,7 +7,6 @@ from slack_sdk.errors import SlackApiError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from contextlib import asynccontextmanager
-from slack_sdk.signature import SignatureVerifier
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
@@ -22,11 +21,9 @@ client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
 slack_app = App(
     token=os.environ.get("SLACK_BOT_TOKEN"),
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
-    # process_before_response=True,
-    # request_verification_enabled=False,
-    # ignoring_self_events_enabled=False  # self eventsの無視を無効にする
 )
 handler = SlackRequestHandler(slack_app)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -71,6 +68,7 @@ def scheduled_task():
     # 特定のユーザーにDMを送信
     send_dm_to_user("U07E21NGPA7", "定期的なDMだがや")
 
+
 @slack_app.event("message")
 def handle_message_events(body, say, logger):
     logger.debug(f"Received event: {body}")
@@ -85,11 +83,12 @@ def handle_message_events(body, say, logger):
         logger.info("Responding to channel message")
         say(event["text"] + " ですぞえ")
 
+
 @app.post("/slack/events")
 async def slack_events(req: Request):
     return await handler.handle(req)
 
+
 @app.get("/")
 def read_root():
     return {"Hello": "Scheduled Slack Bot World"}
-

--- a/apis/main.py
+++ b/apis/main.py
@@ -1,50 +1,160 @@
 import os
-from fastapi import FastAPI, Request
-from slack_bolt import App
-from slack_bolt.adapter.fastapi import SlackRequestHandler
+from fastapi import FastAPI, Request, Response
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from contextlib import asynccontextmanager
+from slack_sdk.signature import SignatureVerifier
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+# スケジューラの設定
+scheduler = None
 
-slack_app = App(
-    token=os.environ.get("SLACK_BOT_TOKEN"),
-    signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
-    # process_before_response=True,
-    # request_verification_enabled=False,
-    # ignoring_self_events_enabled=False  # self eventsの無視を無効にする
-)
-app = FastAPI()
-handler = SlackRequestHandler(slack_app)
+# Slack clientの初期化
+client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
+signature_verifier = SignatureVerifier(os.environ.get("SLACK_SIGNING_SECRET"))
 
 
-# @slack_app.event("message")
-# def handle_message_events(body, say):
-#     message = body["event"]
-#     say(message["text"]+" ですぞえ")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global scheduler
+    scheduler = BackgroundScheduler()
+    scheduler.add_job(scheduled_task, trigger=IntervalTrigger(minutes=60))
+    scheduler.start()
+    logger.info("Scheduler started")
 
-@slack_app.event("message")
-def handle_message_events(body, say, logger):
-    logger.debug(f"Received event: {body}")
-    event = body["event"]
-    channel_type = event.get("channel_type")
-    logger.info(f"Message received in channel type: {channel_type}")
-    
-    if channel_type == "im":
-        logger.info("Responding to DM")
-        say(event["text"] + " だがや")
-    else:
-        logger.info("Responding to channel message")
-        say(event["text"] + " ですぞえ")
+    yield
+
+    if scheduler:
+        scheduler.shutdown()
+        logger.info("Scheduler shut down")
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+# チャンネルにメッセージに送信する関数
+def send_message_to_channel(channel_id: str, message: str):
+    try:
+        response = client.chat_postMessage(channel=channel_id, text=message)
+        logger.info(f"Message sent: {response['ts']}")
+    except SlackApiError as e:
+        logger.error(f"Error sending message: {e}")
+
+
+def send_dm_to_user(user_id: str, message: str):
+    try:
+        response = client.chat_postMessage(channel=user_id, text=message)
+        logger.info(f"DM sent: {response['ts']}")
+    except SlackApiError as e:
+        logger.error(f"Error sending DM: {e}")
+
+
+# スケジュールされたタスク
+def scheduled_task():
+    # チャンネルにメッセージを送信
+    send_message_to_channel("C07EFMQBMB6", "定期的なチャンネルメッセージですぞえ")
+
+    # 特定のユーザーにDMを送信
+    send_dm_to_user("U07E21NGPA7", "定期的なDMだがや")
 
 
 @app.post("/slack/events")
-async def slack_events(req: Request):
-    return await handler.handle(req)
+async def slack_events(request: Request):
+    # リクエストボディを取得
+    body = await request.body()
+    body_text = body.decode("utf-8")
+    logger.debug(f"Received Slack event: {body_text}")
+
+    # イベントデータの解析
+    event_data = await request.json()
+
+    # URL検証チャレンジへの応答
+    if event_data.get("type") == "url_verification":
+        logger.info("Responding to Slack URL verification challenge")
+        return {"challenge": event_data.get("challenge")}
+
+    # Slack-Signature ヘッダーを取得
+    signature = request.headers.get("X-Slack-Signature", "")
+    # リクエストタイムスタンプを取得
+    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+
+    # リクエストの検証
+    if not signature_verifier.is_valid(body, signature, timestamp):
+        logger.warning("Invalid Slack request signature")
+        return Response(status_code=403, content="Invalid request")
+
+    # その他のイベント処理
+    if event_data.get("type") == "event_callback":
+        event = event_data.get("event", {})
+        event_type = event.get("type")
+
+        if event_type == "message":
+            # メッセージイベントの処理
+            channel = event.get("channel")
+            user = event.get("user")
+            text = event.get("text")
+            logger.info(
+                f"Received message: {text} from user {user} in channel {channel}"
+            )
+
+    return Response(status_code=200)
+
 
 @app.get("/")
 def read_root():
-    return {"Hello": "ngrok World"}
+    return {"Hello": "Scheduled Slack Bot World"}
 
 
+# import os
+# from fastapi import FastAPI, Request
+# from slack_bolt import App
+# from slack_bolt.adapter.fastapi import SlackRequestHandler
+# import logging
+
+# logging.basicConfig(level=logging.DEBUG)
+# logger = logging.getLogger(__name__)
+
+
+# slack_app = App(
+#     token=os.environ.get("SLACK_BOT_TOKEN"),
+#     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
+#     # process_before_response=True,
+#     # request_verification_enabled=False,
+#     # ignoring_self_events_enabled=False  # self eventsの無視を無効にする
+# )
+# app = FastAPI()
+# handler = SlackRequestHandler(slack_app)
+
+
+# # @slack_app.event("message")
+# # def handle_message_events(body, say):
+# #     message = body["event"]
+# #     say(message["text"]+" ですぞえ")
+
+# @slack_app.event("message")
+# def handle_message_events(body, say, logger):
+#     logger.debug(f"Received event: {body}")
+#     event = body["event"]
+#     channel_type = event.get("channel_type")
+#     logger.info(f"Message received in channel type: {channel_type}")
+
+#     if channel_type == "im":
+#         logger.info("Responding to DM")
+#         say(event["text"] + " だがや")
+#     else:
+#         logger.info("Responding to channel message")
+#         say(event["text"] + " ですぞえ")
+
+
+# @app.post("/slack/events")
+# async def slack_events(req: Request):
+#     return await handler.handle(req)
+
+# @app.get("/")
+# def read_root():
+#     return {"Hello": "ngrok World"}

--- a/apis/requirements.txt
+++ b/apis/requirements.txt
@@ -15,3 +15,5 @@ sqlalchemy[asyncio]
 pytest-asyncio
 pytest-cov
 slack-bolt
+slack_sdk
+apscheduler


### PR DESCRIPTION
## 目的
- 

## 実装の概要/やったこと

- このプルリクで何をしたのか？
イベントの起点をFastAPIとSlack Appの両方を併存させた

## 保留/やらないこと

- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）
無し

## できるようになること（ユーザ目線）

- 何ができるようになるのか？（あれば。無いなら「無し」でOK）
SlackからDM・チャットが飛んできたり、SlackがDM・チャットでオウム返しする

## できなくなること（ユーザ目線）

- 何ができなくなるのか？（あれば。無いなら「無し」でOK）
無し

## 動作確認

- どのような動作確認を行ったのか？　結果はどうか？
実際にSlackでDM・チャットを投げる

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
- close #
- @
