### PR TITLE
#2 入力フォームの作成、Good&Newのデータベース保存

### DIFF
--- a/apis/main.py
+++ b/apis/main.py
@@ -6,7 +6,3 @@ app = FastAPI()
 
 app.include_router(slack.router)
 app.include_router(develop.router)
-
-# ロギングの設定
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__name__)

--- a/apis/requirements.txt
+++ b/apis/requirements.txt
@@ -16,3 +16,4 @@ pytest-cov
 slack-bolt
 slack_sdk
 apscheduler
+aiohttp

--- a/apis/routers/slack.py
+++ b/apis/routers/slack.py
@@ -1,10 +1,7 @@
 import os
-from typing import Annotated
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
-from sqlalchemy.ext.asyncio import AsyncSession
-from db_session import get_db
 import logging
 
 # ロギングの設定
@@ -12,8 +9,6 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Slack"])
-
-DbDependency = Annotated[AsyncSession, Depends(get_db)]
 
 # Slackアプリの設定
 slack_app = AsyncApp(

--- a/apis/routers/slack.py
+++ b/apis/routers/slack.py
@@ -1,12 +1,14 @@
 import os
 from typing import Annotated
 from fastapi import APIRouter, Depends, Request
-from slack_bolt import App
-from slack_bolt.adapter.fastapi import SlackRequestHandler
+from slack_bolt.async_app import AsyncApp
+from slack_bolt.adapter.fastapi.async_handler import AsyncSlackRequestHandler
 from sqlalchemy.ext.asyncio import AsyncSession
 from db_session import get_db
 import logging
 
+# ロギングの設定
+logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Slack"])
@@ -14,17 +16,18 @@ router = APIRouter(tags=["Slack"])
 DbDependency = Annotated[AsyncSession, Depends(get_db)]
 
 # Slackアプリの設定
-slack_app = App(
+slack_app = AsyncApp(
     token=os.environ.get("SLACK_BOT_TOKEN"),
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET"),
     # process_before_response=True,
     # request_verification_enabled=False,
     # ignoring_self_events_enabled=False  # self eventsの無視を無効にする
 )
-handler = SlackRequestHandler(slack_app)
+handler = AsyncSlackRequestHandler(slack_app)
 
 # slack_appを定義した後でslack_eventsをインポートする
 from slack_events import parrot_bot
+from slack_events import show_modal_answer, handle_submit_answer
 
 @router.post("/slack/events")
 async def slack_events(req: Request):

--- a/apis/slack_events/handle_submit_answer.py
+++ b/apis/slack_events/handle_submit_answer.py
@@ -1,0 +1,52 @@
+from db_session import get_db
+from database.contents import Content
+from routers.slack import slack_app, logger
+
+
+# 送信された回答をDBに保存
+@slack_app.view("modal_answer")
+async def handle_submit_answer(ack, body, client, view, logger):
+    team_id = body["team"]["id"]
+    user_id = body["user"]["id"]
+    content = view["state"]["values"]["input_1"]["input_content"]["value"]
+    logger.info(f"accept team_id: {team_id}, user_id: {user_id}, content: {content}")
+
+    # 入力値を検証
+    errors = {}
+    if content is None:
+        errors["input_1"] = "この項目は必須です"
+    if len(errors) > 0:
+        await ack(response_action="errors", errors=errors)
+        return
+    
+    # リクエストの確認を行い、モーダルを閉じる
+    await ack()
+    
+    # DBセッションを手動で取得（Slack Boltのイベントリスナーでは、依存性注入が直接使用できないため）
+    async for db in get_db():
+        # ユーザーに送信するメッセージ
+        msg = ""
+        try:
+            # データ作成（id, content_date, is_deliveredは登録時にDB側でデフォルト値が入る）
+            new_content = Content(
+                team_id = team_id,
+                user_id = user_id,
+                content = content,
+            )
+            # DBへ追加
+            db.add(new_content)
+            await db.commit()
+
+            logger.info(f"Successfully saved to database: {content}")
+            msg = "回答を受け付けました :tada: ありがとうございます！"
+
+        except Exception as e:
+            logger.exception(f"Failed to save a answer {e}") 
+            msg = "回答の保存に失敗しました :cry:"
+
+    # ユーザーにメッセージを送信
+    try:
+        await client.chat_postMessage(channel=user_id, text=msg)
+    except e:
+        logger.exception(f"Failed to post a message {e}") 
+

--- a/apis/slack_events/parrot_bot.py
+++ b/apis/slack_events/parrot_bot.py
@@ -1,12 +1,10 @@
-import logging
-from routers.slack import slack_app
-
-logger = logging.getLogger(__name__)
+from routers.slack import slack_app, logger
 
 
 # オウム返しBOT
+# DMへのメッセージに対してはGood&Newを尋ねるように変更（テスト用）
 @slack_app.event("message")
-def handle_message_events(body, say, logger):
+async def handle_message_events(body, say, logger):
     logger.debug(f"Received event: {body}")
     event = body["event"]
     channel_type = event.get("channel_type")
@@ -14,7 +12,20 @@ def handle_message_events(body, say, logger):
     
     if channel_type == "im":
         logger.info("Responding to DM")
-        say(event["text"] + " だがや")
+        await say(
+            blocks=[
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "あなたのGood & Newな事を教えて下さい :eyes:"},
+                "accessory": {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text":"回答する"},
+                    "action_id": "click_button_answer"
+                }
+            }
+        ],
+        text="あなたのGood & Newな事を教えて下さい :eyes:"
+        )
     else:
         logger.info("Responding to channel message")
-        say(event["text"] + " ですぞえ")
+        await say(event["text"] + " ですぞえ")

--- a/apis/slack_events/show_modal_answer.py
+++ b/apis/slack_events/show_modal_answer.py
@@ -1,0 +1,59 @@
+from routers.slack import slack_app, logger
+
+
+# 回答モーダルの表示
+@slack_app.action("click_button_answer")
+async def show_modal_answer(ack, body, client):
+    # アクションを確認したことを即時で応答
+    await ack()
+    modal_view = {
+        "type": "modal",
+        # ビューの識別子
+        "callback_id": "modal_answer",
+        "submit": {
+            "type": "plain_text",
+            "text": "送信",
+            "emoji": True
+        },
+        "close": {
+            "type": "plain_text",
+            "text": "キャンセル",
+            "emoji": True
+        },
+        "title": {
+            "type": "plain_text",
+            "text": "Good & New",
+            "emoji": True
+        },
+        "blocks": [
+                {
+                "type": "section",
+                "text": {
+                    "type": "plain_text",
+                    "text": ":wave: こんにちは！\n\nあなたの、24時間以内に起きた「よかったこと」や「新しい発見」を教えて下さい :star2: ",
+                    "emoji": True
+                    }
+                },
+                {
+                "type": "input",
+                "block_id": "input_1",
+                "label": {
+                    "type": "plain_text",
+                    "text": "Your Good & New",
+                    "emoji": True
+                    },
+                "element": {
+                    "type": "plain_text_input",
+                    "action_id": "input_content",
+                    "multiline": True
+                    }
+                }
+            ]
+        }
+    # モーダルを表示
+    response = await client.views_open(
+        trigger_id=body["trigger_id"],
+        view=modal_view
+    )
+    
+    return response

--- a/apis/slack_events/show_modal_answer.py
+++ b/apis/slack_events/show_modal_answer.py
@@ -30,7 +30,7 @@ async def show_modal_answer(ack, body, client):
                 "type": "section",
                 "text": {
                     "type": "plain_text",
-                    "text": ":wave: こんにちは！\n\nあなたの、24時間以内に起きた「よかったこと」や「新しい発見」を教えて下さい :star2: ",
+                    "text": "こんにちは！ :wave:\n\nあなたの、24時間以内に起きた「よかったこと」や「新しい発見」を教えて下さい :star2: ",
                     "emoji": True
                     }
                 },


### PR DESCRIPTION
## 目的
- 入力モーダルの表示
- 入力されたGood&Newのデータベース保存

## 実装の概要/やったこと
- slack_events/show_modal_answer.pyを作成（入力モーダルの表示）
- slack_events/handle_submit_answer.pyを作成（Good&Newのデータベース保存）
- slack_events/parrot_bot.pyにて、DMへのメッセージに対してはGood&Newを尋ねるように変更（動作テスト用）
- slack_appを同期処理から非同期処理へ変更
  - aiohttpのインストール
- ロギング設定をmain.py→slack.pyへ移動し、importする形へ変更

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- BOTとのDMにメッセージを送信すると、Good&Newを尋ねるメッセージが表示される。（動作テスト用）
- メッセージの「回答する」ボタンをクリックすると、回答用のモーダルが表示される。
- モーダルに入力して「送信する」をクリックすると、回答がDBに保存され、結果のメッセージが表示される。

## できなくなること（ユーザ目線）
- なし

## 動作確認
- 「できるようになること（ユーザ目線）」の内容について自分のslackワークスペースにて動作確認済み。
- phpMyAdminにて、DBに保存されていることを確認済み。

![Untitled1](https://github.com/user-attachments/assets/c3460d58-74ea-40bb-8685-6f3d0d42c950)

![Untitled2](https://github.com/user-attachments/assets/9d83804d-64fa-474e-b707-32be3b747409)

![Untitled3](https://github.com/user-attachments/assets/2bc916d1-92cd-45fb-ae39-ef3983ff82fb)

## その他
- DBセッションが非同期のため、slack_appも非同期にしないといけないようで、変更しています。（slack.py）
→そのため、slack_appのイベントリスナー関数にはasyncをつけて、関数内でもDBやslackと通信する操作は適宜awaitを使用して下さい。
- developのDBアクセスで使用している依存性注入（DbDependency）が、Slack Boltのイベントリスナーでは使用できないようです。そのため、イベントリスナー内ではDBセッションを手動で取得しています。
- @Sen-Megaten4649 
  14時の質問のbuttonに、`"action_id": "click_button_answer"`の指定をお願いします。
  （モーダル表示は、上記のaction_idでトリガーされるようにしています）
- モーダルを扱うために、slackアプリ設定のInteractivity & Shortcuts→Interactivityを有効にして、Request URLにEvent Subscriptionsと同じURLを設定して下さい。

![image](https://github.com/user-attachments/assets/b5c3ef28-e118-4da7-b174-cfb7f54d1c43)

- close #
