### PR TITLE
handle_submit_answer内のDB保存部分をrepository/contentsへ移動 #29

### DIFF
--- a/apis/repository/contents.py
+++ b/apis/repository/contents.py
@@ -5,6 +5,19 @@ from datetime import datetime, timedelta
 
 class Contents:
     @staticmethod
+    async def add(team_id, user_id, content):
+        async for db in get_db():
+            try:
+                # データ作成（id, content_date, is_deliveredは登録時にDB側でデフォルト値が入る）
+                new_content = Content(team_id = team_id, user_id = user_id, content = content)
+                # DBへ追加
+                db.add(new_content)
+                await db.commit()
+            except:
+                raise
+
+
+    @staticmethod
     async def delivery(team_id) -> list[tuple[str, str, str]]:
         # 現在の日付
         current_date = datetime.now()

--- a/apis/slack_events/handle_submit_answer.py
+++ b/apis/slack_events/handle_submit_answer.py
@@ -1,6 +1,5 @@
-from db_session import get_db
-from database.contents import Content
 from routers.slack import slack_app
+from repository.contents import Contents
 
 
 # 送信された回答をDBに保存
@@ -22,27 +21,18 @@ async def handle_submit_answer(ack, body, client, view, logger):
     # リクエストの確認を行い、モーダルを閉じる
     await ack()
     
-    # DBセッションを手動で取得（Slack Boltのイベントリスナーでは、依存性注入が直接使用できないため）
-    async for db in get_db():
-        # ユーザーに送信するメッセージ
-        msg = ""
-        try:
-            # データ作成（id, content_date, is_deliveredは登録時にDB側でデフォルト値が入る）
-            new_content = Content(
-                team_id = team_id,
-                user_id = user_id,
-                content = content,
-            )
-            # DBへ追加
-            db.add(new_content)
-            await db.commit()
+    # ユーザーに送信するメッセージ
+    msg = ""
 
-            logger.info(f"Successfully saved to database: {content}")
-            msg = "回答を受け付けました :tada: ありがとうございます！"
+    # データを保存
+    try:
+        await Contents.add(team_id = team_id, user_id = user_id, content = content)
+        logger.info(f"Successfully saved to database: {content}")
+        msg = "回答を受け付けました :tada: ありがとうございます！"
 
-        except Exception as e:
-            logger.exception(f"Failed to save a answer {e}") 
-            msg = "回答の保存に失敗しました :cry:"
+    except Exception as e:
+        logger.exception(f"Failed to save a answer {e}") 
+        msg = "回答の保存に失敗しました :cry:"
 
     # ユーザーにメッセージを送信
     try:

--- a/apis/slack_schedule/delivery.py
+++ b/apis/slack_schedule/delivery.py
@@ -12,9 +12,9 @@ async def delivery():
     today = date.today()
     weekday = today.weekday()  # 0(月曜日)から6(日曜日)が取得できる
 
-    # if weekday >= 5 or jpholiday.is_holiday(today):
-    #     logger.warning("土日祝日のため、メッセージを送信しません")
-    #     return
+    if weekday >= 5 or jpholiday.is_holiday(today):
+        logger.warning("土日祝日のため、メッセージを送信しません")
+        return
 
     # アプリをインストールしている全てのワークスペース情報を取得
     installations = await installation_store.async_find_all()

--- a/apis/slack_schedule/delivery.py
+++ b/apis/slack_schedule/delivery.py
@@ -12,9 +12,9 @@ async def delivery():
     today = date.today()
     weekday = today.weekday()  # 0(月曜日)から6(日曜日)が取得できる
 
-    if weekday >= 5 or jpholiday.is_holiday(today):
-        logger.warning("土日祝日のため、メッセージを送信しません")
-        return
+    # if weekday >= 5 or jpholiday.is_holiday(today):
+    #     logger.warning("土日祝日のため、メッセージを送信しません")
+    #     return
 
     # アプリをインストールしている全てのワークスペース情報を取得
     installations = await installation_store.async_find_all()

--- a/apis/slack_schedule/question.py
+++ b/apis/slack_schedule/question.py
@@ -56,8 +56,6 @@ async def send_question_to_user(token, user):
         return "質問の送信に失敗しました"
     else:
         logger.info(f"{sent_date}：質問を{user['name']}に送信しました")
-        # JSONレスポンスから、質問送信先チャンネルとタイムスタンプを取得
-        return response_data.get("channel"), response_data.get("ts")
 
 
 # Good and New Botから質問を送信する関数


### PR DESCRIPTION
## 目的
- repository/contentsへのコードの統一

## 実装の概要/やったこと
- handle_submit_answer内のDB保存部分をrepository/contentsへ移動
- questionの微修正

## 保留/やらないこと
- なし

## できるようになること（ユーザ目線）
- 変更なし

## できなくなること（ユーザ目線）
- 変更なし

## 動作確認
- ローカルにて動作が変わらないことを確認

## その他

- close #29 
